### PR TITLE
Update optionsGeneric.jsx

### DIFF
--- a/src/panels/addModal/optionsGeneric.jsx
+++ b/src/panels/addModal/optionsGeneric.jsx
@@ -31,6 +31,7 @@ class GenericOptions extends React.Component {
     addVisualization({
       ...selectedViz,
       name,
+      visible: true,
     });
   }
 


### PR DESCRIPTION
Currently the image resizable wrapper does not show up when the viz is added as it uses `options.visible` which is undefined by default.