### PR TITLE
Move zethus component configuration from state to state property

### DIFF
--- a/src/components/styled/index.js
+++ b/src/components/styled/index.js
@@ -132,11 +132,13 @@ export const PanelWrapper = styled.div`
 `;
 
 export const PanelContent = styled.div`
-  width: 100%;
+  width: 10px;
   height: 100%;
   display: flex;
   justify-content: space-between;
   flex-direction: column;
+  flex-grow: 1;
+  flex-shrink: 1;
 `;
 
 export const Container = styled.div`

--- a/src/panels/viewer/index.jsx
+++ b/src/panels/viewer/index.jsx
@@ -11,7 +11,7 @@ const StyledViewport = styled.div`
     top: auto !important;
     left: auto !important;
     right: 0 !important;
-    bottom: 60px !important;
+    bottom: 0 !important;
   }
 `;
 

--- a/src/zethus.jsx
+++ b/src/zethus.jsx
@@ -46,11 +46,14 @@ class Zethus extends React.Component {
     const {
       configuration: { visualizations },
     } = this.state;
-    this.updateConfiguration({
-      visualizations: _.map(visualizations, v =>
-        v.key === key ? { ...v, ...options } : v,
-      ),
-    });
+    this.updateConfiguration(
+      {
+        visualizations: _.map(visualizations, v =>
+          v.key === key ? { ...v, ...options } : v,
+        ),
+      },
+      true,
+    );
   }
 
   updateRosEndpoint(endpoint) {
@@ -66,7 +69,8 @@ class Zethus extends React.Component {
   }
 
   componentWillUnmount() {
-    store.set('zethus_config', this.state);
+    const { configuration } = this.state;
+    store.set('zethus_config', configuration);
   }
 
   updateGlobalOptions(path, option) {
@@ -75,9 +79,12 @@ class Zethus extends React.Component {
     } = this.state;
     const clonedGlobalOptions = _.cloneDeep(globalOptions);
     _.set(clonedGlobalOptions, path, option);
-    this.updateConfiguration({
-      globalOptions: clonedGlobalOptions,
-    });
+    this.updateConfiguration(
+      {
+        globalOptions: clonedGlobalOptions,
+      },
+      true,
+    );
   }
 
   removeVisualization(e) {
@@ -87,9 +94,12 @@ class Zethus extends React.Component {
     const {
       configuration: { visualizations },
     } = this.state;
-    this.updateConfiguration({
-      visualizations: _.filter(visualizations, v => v.key !== vizId),
-    });
+    this.updateConfiguration(
+      {
+        visualizations: _.filter(visualizations, v => v.key !== vizId),
+      },
+      true,
+    );
   }
 
   toggleVisibility(e) {
@@ -99,16 +109,19 @@ class Zethus extends React.Component {
     const {
       configuration: { visualizations },
     } = this.state;
-    this.updateConfiguration({
-      visualizations: _.map(visualizations, v =>
-        v.key === vizId
-          ? {
-              ...v,
-              visible: !!(_.isBoolean(v.visible) && !v.visible),
-            }
-          : v,
-      ),
-    });
+    this.updateConfiguration(
+      {
+        visualizations: _.map(visualizations, v =>
+          v.key === vizId
+            ? {
+                ...v,
+                visible: !!(_.isBoolean(v.visible) && !v.visible),
+              }
+            : v,
+        ),
+      },
+      true,
+    );
   }
 
   addVisualization(vizOptions) {

--- a/src/zethus.jsx
+++ b/src/zethus.jsx
@@ -15,7 +15,7 @@ class Zethus extends React.Component {
       props.configuration || store.get('zethus_config') || {};
 
     this.state = {
-      ..._.merge(DEFAULT_CONFIG, providedConfig),
+      configuration: _.merge(DEFAULT_CONFIG, providedConfig),
     };
     this.updateVizOptions = this.updateVizOptions.bind(this);
     this.updateRosEndpoint = this.updateRosEndpoint.bind(this);
@@ -27,23 +27,26 @@ class Zethus extends React.Component {
   }
 
   updateConfiguration(configuration, replaceOnExisting) {
-    let newState = {};
+    const { configuration: oldConfiguration } = this.state;
+    let newConfiguration = {};
     if (replaceOnExisting) {
-      newState = {
-        ...this.state,
+      newConfiguration = {
+        ...oldConfiguration,
         ...configuration,
       };
     } else {
-      newState = {
-        ..._.merge(this.state, configuration),
+      newConfiguration = {
+        ..._.merge(oldConfiguration, configuration),
       };
     }
-    this.setState({ state: newState });
+    this.setState({ configuration: newConfiguration });
   }
 
   updateVizOptions(key, options) {
-    const { visualizations } = this.state;
-    this.setState({
+    const {
+      configuration: { visualizations },
+    } = this.state;
+    this.updateConfiguration({
       visualizations: _.map(visualizations, v =>
         v.key === key ? { ...v, ...options } : v,
       ),
@@ -51,8 +54,10 @@ class Zethus extends React.Component {
   }
 
   updateRosEndpoint(endpoint) {
-    const { ros } = this.state;
-    this.setState({
+    const {
+      configuration: { ros },
+    } = this.state;
+    this.updateConfiguration({
       ros: {
         ...ros,
         endpoint,
@@ -65,10 +70,12 @@ class Zethus extends React.Component {
   }
 
   updateGlobalOptions(path, option) {
-    const { globalOptions } = this.state;
+    const {
+      configuration: { globalOptions },
+    } = this.state;
     const clonedGlobalOptions = _.cloneDeep(globalOptions);
     _.set(clonedGlobalOptions, path, option);
-    this.setState({
+    this.updateConfiguration({
       globalOptions: clonedGlobalOptions,
     });
   }
@@ -77,8 +84,10 @@ class Zethus extends React.Component {
     const {
       dataset: { id: vizId },
     } = e.target;
-    const { visualizations } = this.state;
-    this.setState({
+    const {
+      configuration: { visualizations },
+    } = this.state;
+    this.updateConfiguration({
       visualizations: _.filter(visualizations, v => v.key !== vizId),
     });
   }
@@ -87,8 +96,10 @@ class Zethus extends React.Component {
     const {
       dataset: { id: vizId },
     } = e.target;
-    const { visualizations } = this.state;
-    this.setState({
+    const {
+      configuration: { visualizations },
+    } = this.state;
+    this.updateConfiguration({
       visualizations: _.map(visualizations, v =>
         v.key === vizId
           ? {
@@ -101,8 +112,10 @@ class Zethus extends React.Component {
   }
 
   addVisualization(vizOptions) {
-    const { visualizations } = this.state;
-    this.setState({
+    const {
+      configuration: { visualizations },
+    } = this.state;
+    this.updateConfiguration({
       visualizations: [
         ...visualizations,
         {
@@ -114,9 +127,10 @@ class Zethus extends React.Component {
   }
 
   render() {
+    const { configuration } = this.state;
     return (
       <Panels
-        configuration={this.state}
+        configuration={configuration}
         addVisualization={this.addVisualization}
         removeVisualization={this.removeVisualization}
         toggleVisibility={this.toggleVisibility}


### PR DESCRIPTION
updateConfiguration previously set the property `state` on state. Renamed it to `configuration` and changed other functions to handle the same.
This will also be useful later when zethus component needs other things in state and not just the config.

Minor CSS fixes for panels to cover width and not overflow